### PR TITLE
PAIGE-270: Fixed the image sizing before and after DeepAR

### DIFF
--- a/android/src/main/java/com/camera_deep_ar/LoadImageHandler.java
+++ b/android/src/main/java/com/camera_deep_ar/LoadImageHandler.java
@@ -201,5 +201,4 @@ public class LoadImageHandler {
         String filename = "rotated"+System.currentTimeMillis()+".png";
         MediaStore.Images.Media.insertImage(mContext.get().getContentResolver(), bitmap, filename , "Description.");
     }
-
 }

--- a/android/src/main/java/com/camera_deep_ar/LoadImageHandler.java
+++ b/android/src/main/java/com/camera_deep_ar/LoadImageHandler.java
@@ -93,14 +93,12 @@ public class LoadImageHandler {
             resizedBitmap = selectedImage.copy(selectedImage.getConfig(), true);
         }
 
-
         width = resizedBitmap.getWidth();
         height = resizedBitmap.getHeight();
 
         Log.d("DAMON", "HEIGHT: " + height + " WIDTH: " + width);
 
         byte[] nv21Bytes = getNV21(width, height, resizedBitmap);
-
 
         nv21bb = ByteBuffer.allocateDirect(nv21Bytes.length);
         nv21bb.order(ByteOrder.nativeOrder());
@@ -191,8 +189,6 @@ public class LoadImageHandler {
 
         return dest;
     }
-
-
 
     public static Bitmap rotateBitmap(Bitmap source, float angle)
     {


### PR DESCRIPTION
Turns out that the issue was that the images, once loaded, needed to be aligned relative to a 'bytes per pixel' value of 16 (4 channels * 4 bytes per channel).
After resizing the image to match this requirement, it can safely be saved out and reloaded without any 'zooming' issues (which was related to a mismatch of input and output sizes.

PAIGE-272: Fixed init order + removed stale refs
As the imageGrabber is set up after the Android Surface has been initialized, changeImagePath may be called before that as the former operation is done async.
I moved the changeImagePath flow into its own function that will attempt to invoke itself if the surface isn't created yet.
I also took the time to clean up other objects which may be holding refs to the CameraDeepArView, keeping it alive longer than it should. I was getting exceptions early on each time I moved to a new session because the previous session was still trying to invoke 'reloadBitmap'.